### PR TITLE
Update to use Laravel Zero 6

### DIFF
--- a/app/Commands/NewCommand.php
+++ b/app/Commands/NewCommand.php
@@ -24,14 +24,14 @@ class NewCommand extends Command
     /**
      * Holds an instance of the composer service.
      *
-     * @var \LaravelZero\Framework\Contracts\Providers\Composer
+     * @var \LaravelZero\Framework\Contracts\Providers\ComposerContract
      */
     protected $composer;
 
     /**
      * Creates a new instance of the NewCommand class.
      *
-     * @param \LaravelZero\Framework\Contracts\Providers\Composer $composer
+     * @param \LaravelZero\Framework\Contracts\Providers\ComposerContract $composer
      */
     public function __construct(ComposerContract $composer)
     {

--- a/composer.json
+++ b/composer.json
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": "^7.1.3"
+        "php": "^7.2"
     },
     "require-dev": {
-        "laravel-zero/framework": "5.8.*",
+        "laravel-zero/framework": "^6.0",
         "padraic/phar-updater": "^1.0.6"
     },
     "autoload": {


### PR DESCRIPTION
This updates the installer to use Laravel Zero v6. It now requires PHP 7.2 by default.

It also updates invalid references to use the `ComposerContract` interface.